### PR TITLE
cisTEM 1.0.0-beta

### DIFF
--- a/cistem/README.md
+++ b/cistem/README.md
@@ -1,0 +1,16 @@
+## Installation README
+
+* Website:  
+            https://cistem.org/software 
+* Source:   
+            https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-intel-linux.tar.gz?file=1&type=cistem_details&id=37&force=0&s3fs=1
+
+* Licence:  
+            GPL v2 - refer to the file 'COPYING' in the source code which can be downloaded from the website.
+
+* Run:      
+            singularity exec imageFileName.simg cisTEM
+
+* Test:     
+            singularity exec imageFileName.simg cisTEM
+

--- a/cistem/Singularity.cisTEM-1.0.0-beta
+++ b/cistem/Singularity.cisTEM-1.0.0-beta
@@ -1,0 +1,60 @@
+Bootstrap: shub
+From:      Characterisation-Virtual-Laboratory/CharacterisationVL-Software:1804
+
+%labels
+    MAINTAINER_NAME  Jay van Schyndel
+    MAINTAINER_EMAIL jay.vanschyndel@monash.edu
+
+    APPLICATION_NAME ubuntu
+    APPLICATION_VERSION 18.04
+
+    HARDWARE CPU
+
+    LAST_UPDATED 10-MAY-2019
+
+%environment
+    CISTEM_PATH="/opt/cistem-1.0.0-beta"
+    export PATH="$CISTEM_PATH:$PATH"
+
+%post -c /bin/bash
+    echo "*********************************************************"
+    echo "Setup and display environment"
+    echo "*********************************************************"
+    export LC_ALL=en_AU.UTF-8
+    export LANGUAGE=en_AU.UTF-8
+    export DEBIAN_FRONTEND=noninteractive
+    echo $LC_ALL
+    echo $LANGUAGE
+    echo $DEBIAN_FRONTEND
+    echo "*********************************************************"
+    echo "Install repositories"
+    echo "*********************************************************"
+    apt-get install -y software-properties-common
+    apt-add-repository -y 'deb http://us.archive.ubuntu.com/ubuntu/ bionic main restricted'
+    apt-add-repository -y 'deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted'
+    apt-add-repository -y 'deb http://us.archive.ubuntu.com/ubuntu/ bionic universe'
+    apt-add-repository -y 'deb http://us.archive.ubuntu.com/ubuntu/ bionic-updates universe'
+    echo "*********************************************************"
+    echo "Update repositories and install desktop"
+    echo "*********************************************************"
+    apt update
+    apt upgrade -y
+    apt install -y locales
+    locale-gen en_AU.UTF-8
+
+    echo "########################################"
+    echo "# Installing cisTEM - 1.0.0-beta-intel #"
+    echo "########################################"
+
+    echo "Installing dependencies"
+    apt install -y libgtk2.0-0 libgtk2.0-dev libcanberra-gtk-module
+
+    cd /opt
+    #The website URL is https://cistem.org/system/tdf/upload3/cistem-1.0.0-beta-intel-linux.tar.gz?file=1&type=cistem_details&id=37&force=0&s3fs=1 It redirects to AWS. Using the direct link
+    wget https://cistem.s3.amazonaws.com/cistem-1.0.0-beta-intel-linux.tar.gz
+   
+    tar -zxvf cistem-1.0.0-beta-intel-linux.tar.gz
+
+
+%runscript
+    $*


### PR DESCRIPTION
Container built ready to go.
Not deployed on M3 as cisTEM 1.0.0-beta already exists.